### PR TITLE
fix(sanitycheck): flow id

### DIFF
--- a/src/test/resources/sanity-checks/write_query_flux.yaml
+++ b/src/test/resources/sanity-checks/write_query_flux.yaml
@@ -1,4 +1,4 @@
-id: write_test
+id: write_query_flux
 namespace: sanitychecks.plugin-influxdb
 
 inputs:

--- a/src/test/resources/sanity-checks/write_query_influxql.yaml
+++ b/src/test/resources/sanity-checks/write_query_influxql.yaml
@@ -1,4 +1,4 @@
-id: write_test
+id: write_query_influxql
 namespace: sanitychecks.plugin-influxdb
 
 inputs:


### PR DESCRIPTION
Flow id are wrongly named and cause error in sanitychecks runs