### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.4.2-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/main/java/io/kestra/plugin/influxdb/AbstractLoad.java
+++ b/src/main/java/io/kestra/plugin/influxdb/AbstractLoad.java
@@ -1,7 +1,7 @@
 package io.kestra.plugin.influxdb;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +71,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
      * @param inputStream the source data
      * @return a Flux of Points
      */
-    protected abstract Flux<Point> source(RunContext runContext, BufferedReader inputStream) throws Exception;
+    protected abstract Flux<Point> source(RunContext runContext, InputStream inputStream) throws Exception;
 
     @Override
     public Output run(RunContext runContext) throws Exception {
@@ -81,7 +81,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
 
         try (
             InfluxDBClient client = this.connection.client(runContext);
-            BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE)
+            InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)
         ) {
             WriteApiBlocking writeApi = client.getWriteApiBlocking();
             String renderedBucket = runContext.render(bucket).as(String.class).orElseThrow();

--- a/src/main/java/io/kestra/plugin/influxdb/AbstractQuery.java
+++ b/src/main/java/io/kestra/plugin/influxdb/AbstractQuery.java
@@ -1,13 +1,14 @@
 package io.kestra.plugin.influxdb;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.runners.RunContext;
@@ -18,7 +19,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -45,7 +45,7 @@ public abstract class AbstractQuery extends AbstractTask {
     protected URI storeResults(RunContext runContext, List<Map<String, Object>> results) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             Flux<Map<String, Object>> recordFlux = Flux.fromIterable(results);
             FileSerde.writeAll(output, recordFlux).block();
             return runContext.storage().putFile(tempFile);

--- a/src/main/java/io/kestra/plugin/influxdb/AbstractTask.java
+++ b/src/main/java/io/kestra/plugin/influxdb/AbstractTask.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.influxdb;
 import com.influxdb.client.InfluxDBClient;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
@@ -14,7 +15,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString

--- a/src/main/java/io/kestra/plugin/influxdb/InfluxDBConnection.java
+++ b/src/main/java/io/kestra/plugin/influxdb/InfluxDBConnection.java
@@ -8,6 +8,7 @@ import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.InfluxDBClientOptions;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 
@@ -17,7 +18,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import okhttp3.OkHttpClient;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString

--- a/src/main/java/io/kestra/plugin/influxdb/Load.java
+++ b/src/main/java/io/kestra/plugin/influxdb/Load.java
@@ -1,6 +1,6 @@
 package io.kestra.plugin.influxdb;
 
-import java.io.BufferedReader;
+import java.io.InputStream;
 import java.util.*;
 
 import com.influxdb.client.domain.WritePrecision;
@@ -8,6 +8,7 @@ import com.influxdb.client.write.Point;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
@@ -23,7 +24,6 @@ import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 import static io.kestra.plugin.influxdb.utils.TimeUtils.toInstant;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -86,7 +86,7 @@ public class Load extends AbstractLoad {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected Flux<Point> source(RunContext runContext, BufferedReader inputStream) throws Exception {
+    protected Flux<Point> source(RunContext runContext, InputStream inputStream) throws Exception {
         String renderedMeasurement = runContext.render(measurement).as(String.class).orElseThrow();
         String renderedTimeField = runContext.render(timeField).as(String.class).orElse(null);
         List<String> renderedTags = runContext.render(tags).asList(String.class);

--- a/src/main/java/io/kestra/plugin/influxdb/Write.java
+++ b/src/main/java/io/kestra/plugin/influxdb/Write.java
@@ -11,6 +11,7 @@ import com.influxdb.client.domain.WritePrecision;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -20,7 +21,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 /**
  * Task for writing line protocol data directly to InfluxDB

--- a/src/test/java/io/kestra/plugin/influxdb/LoadTest.java
+++ b/src/test/java/io/kestra/plugin/influxdb/LoadTest.java
@@ -3,7 +3,9 @@ package io.kestra.plugin.influxdb;
 import java.io.*;
 import java.net.URI;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,6 +52,14 @@ class LoadTest {
         }
 
         URI uri = storageInterface.put(MAIN_TENANT, null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        // Verify ION read roundtrip
+        try (InputStream is = new BufferedInputStream(storageInterface.get(MAIN_TENANT, null, uri), FileSerde.BUFFER_SIZE)) {
+            List<Object> result = new ArrayList<>();
+            FileSerde.read(is, result::add);
+            assertThat(result.size(), is(5));
+            assertThat(((Map<String, Object>) result.get(0)).get("sensor"), is("sensor-0"));
+        }
 
         Load task = Load.builder()
             .connection(


### PR DESCRIPTION
Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155).

## Changes
- `gradle.properties`: bump `kestraVersion` from 1.3.13 to 1.3.19
- `AbstractLoad.java`: `BufferedReader`/`InputStreamReader` → `BufferedInputStream`/`InputStream`
- `AbstractQuery.java`: `BufferedWriter`/`FileWriter` → `BufferedOutputStream`/`FileOutputStream`
- `Load.java`: update `source()` signature from `BufferedReader` to `InputStream`