### PR TITLE
refactor: replace deprecated tasks and filters

### DIFF
--- a/src/main/java/io/kestra/plugin/influxdb/FluxTrigger.java
+++ b/src/main/java/io/kestra/plugin/influxdb/FluxTrigger.java
@@ -42,7 +42,7 @@ import lombok.experimental.SuperBuilder;
                     tasks:
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
-                        format: "{{ json(taskrun.value) }}"
+                        format: "{{ fromJson(taskrun.value) }}"
                 triggers:
                   - id: watch
                     type: io.kestra.plugin.influxdb.FluxTrigger


### PR DESCRIPTION
Replaces deprecated task identifiers and Pebble filters with their current equivalents